### PR TITLE
Criar busca/criação de grupo

### DIFF
--- a/src/main/java/com/bsg/trustedone/mapper/GroupMapper.java
+++ b/src/main/java/com/bsg/trustedone/mapper/GroupMapper.java
@@ -1,5 +1,6 @@
 package com.bsg.trustedone.mapper;
 
+import com.bsg.trustedone.dto.GroupCreationDto;
 import com.bsg.trustedone.dto.GroupDto;
 import com.bsg.trustedone.entity.Group;
 import org.springframework.stereotype.Component;
@@ -12,6 +13,13 @@ public class GroupMapper {
                 .groupId(entity.getGroupId())
                 .name(entity.getName())
                 .description(entity.getDescription())
+                .build();
+    }
+
+    public GroupCreationDto toCreationDto(GroupDto groupDto) {
+        return GroupCreationDto.builder()
+                .name(groupDto.getName())
+                .description(groupDto.getDescription())
                 .build();
     }
 }

--- a/src/main/java/com/bsg/trustedone/service/GroupService.java
+++ b/src/main/java/com/bsg/trustedone/service/GroupService.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static java.util.Objects.isNull;
+
 @Service
 @RequiredArgsConstructor
 public class GroupService {
@@ -76,4 +78,17 @@ public class GroupService {
         return groupMapper.toDto(groupRepository.save(group));
     }
 
+    public GroupDto findOrCreateGroup(GroupDto group) {
+        if (isNull(group)) {
+            return GroupDto.builder().build();
+        }
+
+        if (isNull(group.getGroupId())) {
+            return this.createGroup(groupMapper.toCreationDto(group));
+        }
+
+        return this.groupRepository.findById(group.getGroupId())
+                .map(groupMapper::toDto)
+                .orElseGet(() -> this.createGroup(groupMapper.toCreationDto(group)));
+    };
 }


### PR DESCRIPTION
Na GroupService, criar um método para buscar ou criar um grupo. Deve seguir a seguinte regra:

- Caso haja um groupId, buscar pelo mesmo. Caso a busca não retorne nada, criar um novo 
- Caso não haja groupId, criar um grupo novo.

Lembrar de passar pelos processos de validação ao criar um grupo.